### PR TITLE
Add rotateCloudWithRobotHeading config property to orbiter_preprocessing

### DIFF
--- a/orbiter_preprocessing.orogen
+++ b/orbiter_preprocessing.orogen
@@ -62,6 +62,9 @@ task_context 'Task' do
         doc 'Ratio of the distance to voxel grid edge (cropSize / 2) ' +
             'the robot must cover before a new cloud is processed'
 
+    property('rotateCloudWithRobotHeading', 'bool', true).
+        doc 'Rotate (yaw) orbiter cloud with the robot heading from the robotPose input port'
+
     ####### Input Ports #######
     input_port('robotPose', '/base/samples/RigidBodyState').
         doc '6D pose of the robot, either directly from robot or from GPS'

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -122,16 +122,18 @@ void Task::transformCloud(void) {
     offsetTF.linear() = offsetQuaternion.toRotationMatrix();
     pcl::transformPointCloud(*cloud_, *preprocessedCloud_, offsetTF);
 
-    const double robotYaw = robotPose_.getYaw() - M_PI / 2.;
-    auto robotTF = Eigen::Affine3d::Identity();
-    const auto robotQuaternion = Eigen::Quaterniond(
-            Eigen::AngleAxisd(robotYaw, Eigen::Vector3d::UnitZ()) *
-            Eigen::AngleAxisd(0., Eigen::Vector3d::UnitY()) *
-            Eigen::AngleAxisd(0., Eigen::Vector3d::UnitX()));
+    if (_rotateCloudWithRobotHeading.rvalue()) {
+        const double robotYaw = robotPose_.getYaw() - M_PI / 2.;
+        auto robotTF = Eigen::Affine3d::Identity();
+        const auto robotQuaternion = Eigen::Quaterniond(
+                Eigen::AngleAxisd(robotYaw, Eigen::Vector3d::UnitZ()) *
+                Eigen::AngleAxisd(0., Eigen::Vector3d::UnitY()) *
+                Eigen::AngleAxisd(0., Eigen::Vector3d::UnitX()));
 
-    robotTF.translation() = Eigen::Vector3d::Zero();
-    robotTF.linear() = robotQuaternion.toRotationMatrix();
-    pcl::transformPointCloud(*preprocessedCloud_, *preprocessedCloud_, robotTF);
+        robotTF.translation() = Eigen::Vector3d::Zero();
+        robotTF.linear() = robotQuaternion.toRotationMatrix();
+        pcl::transformPointCloud(*preprocessedCloud_, *preprocessedCloud_, robotTF);
+    }
 }
 
 void Task::downsampleCloud(void) {


### PR DESCRIPTION
As far as I understand GA Slam, the local map is not rotated with the heading of the robot and always stays oriented in the global frame frame to reduce the computational complexity. This leads me to think that also the global map should **not** be rotated and be aligned with the global reference frame to allow fast matching between local and global maps. This PR introduces a property to the orbiter_preprocessing to disable the rotation with the robotPose (from input port)