### PR TITLE
Introduce gpsRefFrame boolean config property

### DIFF
--- a/orbiter_preprocessing.orogen
+++ b/orbiter_preprocessing.orogen
@@ -31,7 +31,8 @@ task_context 'Task' do
     property('sorStdMultiplier', 'double', 1.0).
         doc 'Standard deviation multiplier for marking outliers in SOR filter'
 
-    property('cloudYawOffset', 'double', -Math::PI/2).
+    #property('cloudYawOffset', 'double', -Math::PI/2).
+    property('cloudYawOffset', 'double', 0.0).
         doc 'Yaw offset of input point cloud'
 
     property('cloudEastingOffset', 'double').

--- a/orbiter_preprocessing.orogen
+++ b/orbiter_preprocessing.orogen
@@ -63,6 +63,9 @@ task_context 'Task' do
         doc 'Ratio of the distance to voxel grid edge (cropSize / 2) ' +
             'the robot must cover before a new cloud is processed'
 
+    property('gpsRefFrame', 'bool', false).
+        doc 'Use the GPS reference frame'
+
     ####### Input Ports #######
     input_port('robotPose', '/base/samples/RigidBodyState').
         doc '6D pose of the robot, either directly from robot or from GPS'

--- a/orbiter_preprocessing.orogen
+++ b/orbiter_preprocessing.orogen
@@ -31,8 +31,7 @@ task_context 'Task' do
     property('sorStdMultiplier', 'double', 1.0).
         doc 'Standard deviation multiplier for marking outliers in SOR filter'
 
-    #property('cloudYawOffset', 'double', -Math::PI/2).
-    property('cloudYawOffset', 'double', 0.0).
+    property('cloudYawOffset', 'double', -Math::PI/2).
         doc 'Yaw offset of input point cloud'
 
     property('cloudEastingOffset', 'double').

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -114,30 +114,34 @@ void Task::transformCloud(void) {
             Eigen::AngleAxisd(offsetYaw, Eigen::Vector3d::UnitZ()) *
             Eigen::AngleAxisd(0., Eigen::Vector3d::UnitY()) *
             Eigen::AngleAxisd(0., Eigen::Vector3d::UnitX()));
-/*
-    offsetTF.translation() = Eigen::Vector3d(
-            - northingReference_ - robotPose_.position.y(),
-            eastingReference_ + robotPose_.position.x(),
-            elevationReference_ + robotPose_.position.z());
-*/
-    offsetTF.translation() = Eigen::Vector3d(
+
+    if (_gpsRefFrame.rvalue()) {
+        offsetTF.translation() = Eigen::Vector3d(
             -(eastingReference_ + robotPose_.position.x()),
             -(northingReference_ + robotPose_.position.y()),
             elevationReference_ + robotPose_.position.z());
+    } else {
+        offsetTF.translation() = Eigen::Vector3d(
+            - northingReference_ - robotPose_.position.y(),
+            eastingReference_ + robotPose_.position.x(),
+            elevationReference_ + robotPose_.position.z());
+    }
+    
     offsetTF.linear() = offsetQuaternion.toRotationMatrix();
     pcl::transformPointCloud(*cloud_, *preprocessedCloud_, offsetTF);
-/*
-    const double robotYaw = robotPose_.getYaw() - M_PI / 2.;
-    auto robotTF = Eigen::Affine3d::Identity();
-    const auto robotQuaternion = Eigen::Quaterniond(
-            Eigen::AngleAxisd(robotYaw, Eigen::Vector3d::UnitZ()) *
-            Eigen::AngleAxisd(0., Eigen::Vector3d::UnitY()) *
-            Eigen::AngleAxisd(0., Eigen::Vector3d::UnitX()));
 
-    robotTF.translation() = Eigen::Vector3d::Zero();
-    robotTF.linear() = robotQuaternion.toRotationMatrix();
-    pcl::transformPointCloud(*preprocessedCloud_, *preprocessedCloud_, robotTF);
-*/
+    if (!_gpsRefFrame.rvalue()) {
+        const double robotYaw = robotPose_.getYaw() - M_PI / 2.;
+        auto robotTF = Eigen::Affine3d::Identity();
+        const auto robotQuaternion = Eigen::Quaterniond(
+                Eigen::AngleAxisd(robotYaw, Eigen::Vector3d::UnitZ()) *
+                Eigen::AngleAxisd(0., Eigen::Vector3d::UnitY()) *
+                Eigen::AngleAxisd(0., Eigen::Vector3d::UnitX()));
+
+        robotTF.translation() = Eigen::Vector3d::Zero();
+        robotTF.linear() = robotQuaternion.toRotationMatrix();
+        pcl::transformPointCloud(*preprocessedCloud_, *preprocessedCloud_, robotTF);
+    }
 }
 
 void Task::downsampleCloud(void) {

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -114,14 +114,19 @@ void Task::transformCloud(void) {
             Eigen::AngleAxisd(offsetYaw, Eigen::Vector3d::UnitZ()) *
             Eigen::AngleAxisd(0., Eigen::Vector3d::UnitY()) *
             Eigen::AngleAxisd(0., Eigen::Vector3d::UnitX()));
-
+/*
     offsetTF.translation() = Eigen::Vector3d(
             - northingReference_ - robotPose_.position.y(),
             eastingReference_ + robotPose_.position.x(),
             elevationReference_ + robotPose_.position.z());
+*/
+    offsetTF.translation() = Eigen::Vector3d(
+            -(eastingReference_ + robotPose_.position.x()),
+            -(northingReference_ + robotPose_.position.y()),
+            elevationReference_ + robotPose_.position.z());
     offsetTF.linear() = offsetQuaternion.toRotationMatrix();
     pcl::transformPointCloud(*cloud_, *preprocessedCloud_, offsetTF);
-
+/*
     const double robotYaw = robotPose_.getYaw() - M_PI / 2.;
     auto robotTF = Eigen::Affine3d::Identity();
     const auto robotQuaternion = Eigen::Quaterniond(
@@ -132,6 +137,7 @@ void Task::transformCloud(void) {
     robotTF.translation() = Eigen::Vector3d::Zero();
     robotTF.linear() = robotQuaternion.toRotationMatrix();
     pcl::transformPointCloud(*preprocessedCloud_, *preprocessedCloud_, robotTF);
+*/
 }
 
 void Task::downsampleCloud(void) {


### PR DESCRIPTION
If the config property is set to true, we transform the orbiter point cloud to the gps reference frame. This is required for the GA Slam